### PR TITLE
Update Go version to 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/aarsstjerner
 
-go 1.22.0
+go 1.22.1
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Update Go version to 1.22.1.

See [the release history](https://go.dev/doc/devel/release#go1.22.1).