### PR TITLE
Test Go unstable version 1.24rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/aarsstjerner
 
-go 1.23.6
+go 1.24rc3
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Test Go unstable version 1.24rc3.

See [the draft release notes](https://tip.golang.org/doc/go1.24).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!