### PR TITLE
Test Go unstable version 1.25rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/aarsstjerner
 
-go 1.24.4
+go 1.25rc1
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Test Go unstable version 1.25rc1.

See [the draft release notes](https://tip.golang.org/doc/go1.25).

This pull request is only intented for getting feedback on compatibility with future Go versions. Don't merge it!