### PR TITLE
Update Go version to 1.24.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/aarsstjerner
 
-go 1.24.4
+go 1.24.5
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Update Go version to 1.24.5.

See [the release history](https://go.dev/doc/devel/release#go1.24.5).