### PR TITLE
Update Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/spejder/aarsstjerner
 
-go 1.24.6
+go 1.25.0
 
 require (
 	bitbucket.org/long174/go-odoo v1.12.1


### PR DESCRIPTION
Update Go version to 1.25.0.

See [the release history](https://go.dev/doc/devel/release#go1.25.0).