### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: Lint
+permissions:
+  contents: read
 on: pull_request
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/spejder/aarsstjerner/security/code-scanning/3](https://github.com/spejder/aarsstjerner/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block at the workflow root, restricting access to only what’s needed. In this workflow, all jobs simply run lint checks and only need read access to repository contents. Rarely will lint jobs need to write artifacts to the repo or modify issues/PRs. The safest fix is to add `permissions: contents: read` after the workflow `name`. This will ensure all jobs inherit the read-only permission unless locally overridden. No additional methods, imports, or definitions are required; only a one-line change to .github/workflows/lint.yml is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
